### PR TITLE
Updated docker images; fixed react app build.

### DIFF
--- a/cicd-pipeline.yaml
+++ b/cicd-pipeline.yaml
@@ -151,11 +151,13 @@ Resources:
               - 'build/**/*'
       Environment:
         ComputeType: "BUILD_GENERAL1_SMALL"
-        Image: "aws/codebuild/nodejs:8.11.0"
+        Image: "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
           - Name: AWS_DEFAULT_REGION
             Value: !Ref AWS::Region
+          - Name: PUBLIC_URL
+            Value: '/'
       Name: !Sub ${AWS::StackName}-build-client
       ServiceRole: !Ref CodeBuildServiceRole
 
@@ -177,7 +179,7 @@ Resources:
             files: build/deploymentResult.txt
       Environment:
         ComputeType: "BUILD_GENERAL1_SMALL"
-        Image: "aws/codebuild/nodejs:6.3.1"
+        Image: "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
           - Name: AWS_DEFAULT_REGION


### PR DESCRIPTION
As requested during the lecture at Columbia on 10/19, I've changed the docker images to the latest ones that are supported by Amazon CodeBuild. I haven't mentioned the specific runtime versions for NodeJS letting CodeBuild choose the default runtimes that are available in the image (right now, the default NodeJS version is 12.22.2). The old images [are no longer supported](https://github.com/aws/aws-codebuild-docker-images/tree/master/unsupported_images/nodejs).
Also, I've added an environment variable `PUBLIC_URL` which is used by React `build` script when resolving relative paths. Actually, by default, their script produces a build assuming that your app is hosted at the server root. But if you specify a `homepage` in your `package.json`, it will be considered in handling the paths. The project you selected for the demo (https://github.com/ahfarmer/emoji-search) has the `homepage` specified, so the building script assumed that all the paths should be prefixed by `emoji-search` (and we had it in the index.html during the demo). So, there are at least two ways of solving this issue: either maintain prefixes by specifying `PUBLIC_URL` environment variable or deploy the build artifacts under `emoji-search` folder in the S3 bucket. I chose to host the client at the root, so I specified `PUBLIC_URL`. Some info about this can be found [here](https://create-react-app.dev/docs/deployment/#building-for-relative-paths). It's worth mentioning that this template will work for some React apps (e.g. the ones that don't have `homepage` specified or with `homepage` equal to `.`).